### PR TITLE
 net_response plugin: Read up to 1024 bytes in tcp response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,6 @@ require (
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421
 	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456
-	golang.org/x/tools v0.0.0-20190425150028-36563e24a262
 	gonum.org/v1/gonum v0.6.2 // indirect
 	google.golang.org/api v0.3.1
 	google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107

--- a/go.mod
+++ b/go.mod
@@ -124,6 +124,7 @@ require (
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421
 	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456
+	golang.org/x/tools v0.0.0-20190425150028-36563e24a262
 	gonum.org/v1/gonum v0.6.2 // indirect
 	google.golang.org/api v0.3.1
 	google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107

--- a/go.sum
+++ b/go.sum
@@ -511,6 +511,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190206041539-40960b6deb8e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190425150028-36563e24a262 h1:qsl9y/CJx34tuA7QCPNp86JNJe4spst6Ff8MjvPUdPg=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.6.2 h1:4r+yNT0+8SWcOkXP+63H2zQbN+USnC73cjGUxnDF94Q=

--- a/plugins/inputs/net_response/net_response_test.go
+++ b/plugins/inputs/net_response/net_response_test.go
@@ -274,9 +274,9 @@ func TestTCPMultiLineResponseError(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"net_response",
 		map[string]interface{}{
-			"result_code": uint64(4),
-			"result_type": "string_mismatch",
-			"string_found": false,
+			"result_code":   uint64(4),
+			"result_type":   "string_mismatch",
+			"string_found":  false,
 			"response_time": 1.0,
 		},
 		map[string]string{

--- a/plugins/inputs/net_response/net_response_test.go
+++ b/plugins/inputs/net_response/net_response_test.go
@@ -203,7 +203,7 @@ func TestTCPMultiLineResponseOK1(t *testing.T) {
 	var acc testutil.Accumulator
 
 	// Init plugin
-	sendString := internal.RandomString(100)
+	sendString := internal.RandomString(900) // this + the prior responses is under 1024 bytes.
 	c := NetResponse{
 		Address:     "127.0.0.1:2004",
 		Send:        sendString,

--- a/plugins/inputs/net_response/net_response_test.go
+++ b/plugins/inputs/net_response/net_response_test.go
@@ -397,7 +397,7 @@ func MultiLineTCPServer(t *testing.T, wg *sync.WaitGroup) {
 	tcpServer, _ := net.ListenTCP("tcp", tcpAddr)
 	wg.Done()
 	conn, _ := tcpServer.AcceptTCP()
-	buf := make([]byte, 2048)
+	buf := make([]byte, 2048) // must be greater than connectionReadBufferSize
 	conn.Read(buf)
 	conn.Write([]byte("1 Header Response\r\n"))
 	conn.Write([]byte("2nd line with more data\r\n"))

--- a/plugins/inputs/net_response/net_response_test.go
+++ b/plugins/inputs/net_response/net_response_test.go
@@ -397,7 +397,8 @@ func MultiLineTCPServer(t *testing.T, wg *sync.WaitGroup) {
 	tcpServer, _ := net.ListenTCP("tcp", tcpAddr)
 	wg.Done()
 	conn, _ := tcpServer.AcceptTCP()
-	buf := make([]byte, 2048) // must be greater than connectionReadBufferSize
+	// must be greater than connectionReadBufferSize and the max value we send in tests
+	buf := make([]byte, 2048)
 	conn.Read(buf)
 	conn.Write([]byte("1 Header Response\r\n"))
 	conn.Write([]byte("2nd line with more data\r\n"))

--- a/plugins/inputs/net_response/net_response_test.go
+++ b/plugins/inputs/net_response/net_response_test.go
@@ -397,7 +397,7 @@ func MultiLineTCPServer(t *testing.T, wg *sync.WaitGroup) {
 	tcpServer, _ := net.ListenTCP("tcp", tcpAddr)
 	wg.Done()
 	conn, _ := tcpServer.AcceptTCP()
-	buf := make([]byte, 1024)
+	buf := make([]byte, 2048)
 	conn.Read(buf)
 	conn.Write([]byte("1 Header Response\r\n"))
 	conn.Write([]byte("2nd line with more data\r\n"))


### PR DESCRIPTION
This was already approved previously but I've since removed the forked repo and instead duplicated influxdb/telegraf here.

# Fixes

https://jira.rax.io/browse/SALUS-803

# What

Rather than reading the first line returned from the tcp server, read up to 1024 bytes.

# How

`Read` was reading a partial response most of the time which caused tests to fail intermittently.

When adding a 100ms wait before that step everything would be fine.  To avoid wait times I chose to do a `ReadAll` but to also avoid reading too much data I'm using a `LimitedReader`.  For any standard tcp response it'll read the whole thing and for any large response it'll only read up to 1024 bytes (which is the value i set).

# Why

This allows us to create monitors that match of the string response that comes after the `send` string.

e.g.
For this connection we could set the `expect` to `blocked_clients:0` and it would work.
```
$ telnet mycustomerservice.com 3125
Trying mycustomerservice.com...
Connected to mycustomerservice.com.
Escape character is '^]'.

> info
connected_clients:18
client_longest_output_list:0
client_biggest_input_buf:0
blocked_clients:0
```

It could potentially be used for a basic smtp monitor too by matching on `250`.

```
$ telnet mysmtptest.com 25

Trying mysmtptest.com...
Connected to mysmtptest.com.
Escape character is '^]'.
220 mysmtptest.com ESMTP Postfix

> ehlo me.com
250-mysmtptest.com
250-PIPELINING
250-SIZE 10240000
250-VRFY
250-ETRN
250-AUTH PLAIN LOGIN
250-ENHANCEDSTATUSCODES
250-8BITMIME
250 DSN

> quit
221 2.0.0 Bye
```
