### PR TITLE
Add goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /build
 /telegraf
 /telegraf.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea
 /build
+/dist
 /telegraf
 /telegraf.exe
 /telegraf.gz

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,34 @@
+before:
+  hooks:
+    - go mod download
+project_name: telegraf
+builds:
+- env:
+  - CGO_ENABLED=0
+  main: cmd/telegraf
+  binary: telegraf
+  goos:
+    - darwin
+    - linux
+    - windows
+archive:
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{.Tag}}-SNAPSHOT-{{.ShortCommit}}"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^build:'
+release:
+  github:
+    owner: racker
+    name: telegraf

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,19 +5,26 @@ project_name: telegraf
 builds:
 - env:
   - CGO_ENABLED=0
-  main: cmd/telegraf
+  main: ./cmd/telegraf
   binary: telegraf
   goos:
     - darwin
     - linux
     - windows
-archive:
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+  ignore:
+    - goos: darwin
+      goarch: 386
+archives:
+  -
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    format_overrides:
+      - goos: windows
+        format: zip
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Adds an initial goreleaser config.

I tested with `goreleaser release --rm-dist --skip-validate --debug --skip-publish`

then pushed a first release using `goreleaser release --rm-dist --skip-validate --debug`

https://github.com/racker/telegraf/releases/tag/1.13.4

I think once this PR is merge it should work without the `--skip-validate`