### PR TITLE
Add SMTP Input Plugin

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,7 @@ github.com/caio/go-tdigest v2.3.0+incompatible h1:zP6nR0nTSUzlSqqr7F/LhslPlSZX/f
 github.com/caio/go-tdigest v2.3.0+incompatible/go.mod h1:sHQM/ubZStBUmF1WbB8FAm8q9GjDajLC5T7ydxE3JHI=
 github.com/cenkalti/backoff v2.0.0+incompatible h1:5IIPUHhlnUZbcHQsQou5k1Tn58nJkeJL9U+ig5CHJbY=
 github.com/cenkalti/backoff v2.0.0+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible h1:C29Ae4G5GtYyYMm1aztcyj/J5ckgJm2zwdDajFbx1NY=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/cisco-ie/nx-telemetry-proto v0.0.0-20190531143454-82441e232cf6 h1:57RI0wFkG/smvVTcz7F43+R0k+Hvci3jAVQF9lyMoOo=

--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -137,6 +137,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/salesforce"
 	_ "github.com/influxdata/telegraf/plugins/inputs/sensors"
 	_ "github.com/influxdata/telegraf/plugins/inputs/smart"
+	_ "github.com/influxdata/telegraf/plugins/inputs/smtp"
 	_ "github.com/influxdata/telegraf/plugins/inputs/snmp"
 	_ "github.com/influxdata/telegraf/plugins/inputs/snmp_legacy"
 	_ "github.com/influxdata/telegraf/plugins/inputs/snmp_trap"

--- a/plugins/inputs/smtp/README.md
+++ b/plugins/inputs/smtp/README.md
@@ -66,37 +66,15 @@ Two response time metrics are returned.  One for the initial connection time and
 ### Example Output:
 
 ```
-> smtp,host=myhostname,port=25,result=success,server=localhost body_code=250i,connect_code=220i,connect_time=0.003375849,data_code=354i,ehlo_code=250i,from_code=250i,quit_code=221i,result_code=0i,to_code=250i,total_time=0.01299625 1582748272000000000
+> smtp,host=myhostname,port=25,result=success,server=localhost body_code=250i,connect_code=220i,connect_time=0.003485546,data_code=354i,ehlo_code=250i,from_code=250i,quit_code=221i,result_code=0i,starttls_code=220i,to_code=250i,total_time=0.054421634 1582754343000000000
 ```
 
 When telegraf is running in debug mode the plugin will output some more details before the metrics:
 
 ```
-2020-02-26T20:24:30Z I! Starting Telegraf 1.13.0-rc1
-2020-02-26T20:24:30Z I! Using config file: /etc/telegraf/telegraf.conf
-2020-02-26T20:24:30Z D! [agent] Initializing plugins
-2020-02-26T20:24:30Z I! Dialing tcp connection
-2020-02-26T20:24:30Z I! Received response from connect operation: 220 myhostname ESMTP Postfix (Ubuntu)
-2020-02-26T20:24:30Z I! Executing operation: EHLO example.com
-2020-02-26T20:24:30Z I! Received response from ehlo operation: 250 myhostname
-PIPELINING
-SIZE 10240000
-VRFY
-ETRN
-STARTTLS
-ENHANCEDSTATUSCODES
-8BITMIME
-DSN
-SMTPUTF8
-2020-02-26T20:24:30Z I! Executing operation: MAIL FROM:<me@example.com>
-2020-02-26T20:24:30Z I! Received response from from operation: 250 2.1.0 Ok
-2020-02-26T20:24:30Z I! Executing operation: RCPT TO:<you@example.com>
-2020-02-26T20:24:30Z I! Received response from to operation: 250 2.1.5 Ok
-2020-02-26T20:24:30Z I! Executing operation: DATA
-2020-02-26T20:24:30Z I! Received response from data operation: 354 End data with <CR><LF>.<CR><LF>
-2020-02-26T20:24:30Z I! Sending data payload: this is a test payload
-2020-02-26T20:24:30Z I! Received response from body operation: 250 2.0.0 Ok: queued as 8D68A4269B
-2020-02-26T20:24:30Z I! Executing operation: QUIT
-2020-02-26T20:24:30Z I! Received response from quit operation: 221 2.0.0 Bye
-> smtp,host=myhostname,port=25,result=success,server=localhost body_code=250i,connect_code=220i,connect_time=0.01893857,data_code=354i,ehlo_code=250i,from_code=250i,quit_code=221i,result_code=0i,to_code=250i,total_time=0.03669411 1582748671000000000
+2020-02-26T21:58:28Z I! smtp: Received expected response from connect operation
+2020-02-26T21:58:28Z I! smtp: Received expected response from ehlo operation
+2020-02-26T21:58:28Z I! smtp: Received expected response from starttls operation
+2020-02-26T21:58:28Z I! smtp: Received error response from to operations: 503 5.5.1 Error: need MAIL command
+> smtp,host=myhostname,port=25,result=string_mismatch,server=localhost connect_code=220i,connect_time=0.018595031,ehlo_code=250i,result_code=4i,starttls_code=220i,to_code=503i,total_time=0.06953827 1582754308000000000
 ```

--- a/plugins/inputs/smtp/README.md
+++ b/plugins/inputs/smtp/README.md
@@ -1,0 +1,102 @@
+# SMTP Input Plugin
+
+The input plugin can test a full SMTP session, reporting response times and codes.
+
+With no optional parameters set the plugin will verify the connect and quit codes.  With each additional parameters the plugin will execute it's corresponding command while also reporting the response code seen.
+
+Two response time metrics are returned.  One for the initial connection time and another for all operations to be completed.
+
+### Configuration:
+
+```toml
+# Collect response time and codes for an SMTP session
+[[inputs.smtp]]
+  ## Server address (default localhost)
+  address = "localhost:25"
+
+  ## Set initial connection timeout
+  # timeout = "1s"
+
+  ## Set read timeout
+  # read_timeout = "10s"
+
+  ## Optional value to provide to ehlo command
+  # ehlo = "example.com"
+
+  ## Optional value to provide to mailfrom command
+  # from = "me@example.com"
+
+  ## Optional value to provide to rcptto command
+  # to = "you@example.com"
+
+  ## Optional value to provide to data command
+  # body = "this is a test payload"
+
+  ## Optional whether to issue "starttls" command
+  # starttls = false
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = true
+```
+
+### Metrics:
+
+- smtp
+  - tags:
+    - server
+    - port
+    - result
+  - fields:
+    - connect_time (float, seconds)
+    - total_time (float, seconds)
+    - result_code (int, success = 0, timeout = 1, connection_failed = 2, read_failed = 3, string_mismatch = 4, tls_config_error = 5, command_failed = 6)
+    - connect_code (int, if available)
+    - ehlo_code (int, if available)
+    - starttls_code (int, if available)
+    - from_code (int, if available)
+    - to_code (int, if available)
+    - data_code (int, if available)
+    - body_code (int, if available)
+    - quit_code (int, if available)
+
+### Example Output:
+
+```
+> smtp,host=myhostname,port=25,result=success,server=localhost body_code=250i,connect_code=220i,connect_time=0.003375849,data_code=354i,ehlo_code=250i,from_code=250i,quit_code=221i,result_code=0i,to_code=250i,total_time=0.01299625 1582748272000000000
+```
+
+When telegraf is running in debug mode the plugin will output some more details before the metrics:
+
+```
+2020-02-26T20:24:30Z I! Starting Telegraf 1.13.0-rc1
+2020-02-26T20:24:30Z I! Using config file: /etc/telegraf/telegraf.conf
+2020-02-26T20:24:30Z D! [agent] Initializing plugins
+2020-02-26T20:24:30Z I! Dialing tcp connection
+2020-02-26T20:24:30Z I! Received response from connect operation: 220 myhostname ESMTP Postfix (Ubuntu)
+2020-02-26T20:24:30Z I! Executing operation: EHLO example.com
+2020-02-26T20:24:30Z I! Received response from ehlo operation: 250 myhostname
+PIPELINING
+SIZE 10240000
+VRFY
+ETRN
+STARTTLS
+ENHANCEDSTATUSCODES
+8BITMIME
+DSN
+SMTPUTF8
+2020-02-26T20:24:30Z I! Executing operation: MAIL FROM:<me@example.com>
+2020-02-26T20:24:30Z I! Received response from from operation: 250 2.1.0 Ok
+2020-02-26T20:24:30Z I! Executing operation: RCPT TO:<you@example.com>
+2020-02-26T20:24:30Z I! Received response from to operation: 250 2.1.5 Ok
+2020-02-26T20:24:30Z I! Executing operation: DATA
+2020-02-26T20:24:30Z I! Received response from data operation: 354 End data with <CR><LF>.<CR><LF>
+2020-02-26T20:24:30Z I! Sending data payload: this is a test payload
+2020-02-26T20:24:30Z I! Received response from body operation: 250 2.0.0 Ok: queued as 8D68A4269B
+2020-02-26T20:24:30Z I! Executing operation: QUIT
+2020-02-26T20:24:30Z I! Received response from quit operation: 221 2.0.0 Bye
+> smtp,host=myhostname,port=25,result=success,server=localhost body_code=250i,connect_code=220i,connect_time=0.01893857,data_code=354i,ehlo_code=250i,from_code=250i,quit_code=221i,result_code=0i,to_code=250i,total_time=0.03669411 1582748671000000000
+```

--- a/plugins/inputs/smtp/README.md
+++ b/plugins/inputs/smtp/README.md
@@ -72,9 +72,9 @@ Two response time metrics are returned.  One for the initial connection time and
 When telegraf is running in debug mode the plugin will output some more details before the metrics:
 
 ```
-2020-02-26T21:58:28Z I! smtp: Received expected response from connect operation
-2020-02-26T21:58:28Z I! smtp: Received expected response from ehlo operation
-2020-02-26T21:58:28Z I! smtp: Received expected response from starttls operation
-2020-02-26T21:58:28Z I! smtp: Received error response from to operations: 503 5.5.1 Error: need MAIL command
+2020-02-26T21:58:28Z I! smtp: Received expected response from 'connect' operation
+2020-02-26T21:58:28Z I! smtp: Received expected response from 'ehlo' operation
+2020-02-26T21:58:28Z I! smtp: Received expected response from 'starttls' operation
+2020-02-26T21:58:28Z I! smtp: Received error response from 'to' operation: 503 5.5.1 Error: need MAIL command
 > smtp,host=myhostname,port=25,result=string_mismatch,server=localhost connect_code=220i,connect_time=0.018595031,ehlo_code=250i,result_code=4i,starttls_code=220i,to_code=503i,total_time=0.06953827 1582754308000000000
 ```

--- a/plugins/inputs/smtp/smtp.go
+++ b/plugins/inputs/smtp/smtp.go
@@ -253,7 +253,6 @@ func logMsg(msg string) {
 // Gather is called by telegraf when the plugin is executed on its interval.
 // It will call SMTPGather to generate metrics and also fill an Accumulator that is supplied.
 func (smtp *Smtp) Gather(acc telegraf.Accumulator) error {
-	wlog.SetLevelFromName("DEBUG")
 	// Set default values
 	if smtp.Timeout.Duration == 0 {
 		smtp.Timeout.Duration = time.Second

--- a/plugins/inputs/smtp/smtp.go
+++ b/plugins/inputs/smtp/smtp.go
@@ -223,13 +223,13 @@ func setErrorMetrics(operation Operation, err error, fields map[string]interface
 	var result ResultType
 	if err != nil {
 		if e, ok := err.(net.Error); ok && e.Timeout() {
-			logMsg(fmt.Sprintf("Timed out when performing %s operation", string(operation)))
+			logMsg(fmt.Sprintf("Timed out when performing '%s' operation", string(operation)))
 			result = Timeout
 		} else if operation == Connect {
 			logMsg(fmt.Sprintf("Failed to connect to server"))
 			result = ConnectionFailed
 		} else if e, ok := err.(*textproto.Error); ok && e.Code != 0 {
-			logMsg(fmt.Sprintf("Received error response from %s operations: %d %s",
+			logMsg(fmt.Sprintf("Received error response from '%s' operation: %d %s",
 				string(operation), e.Code, e.Msg))
 
 			fields[string(operation)+"_code"] = e.Code
@@ -243,7 +243,7 @@ func setErrorMetrics(operation Operation, err error, fields map[string]interface
 }
 
 func setResponseCodeMetric(operation Operation, expectedCode int, fields map[string]interface{}, tags map[string]string) {
-	logMsg(fmt.Sprintf("Received expected response from %s operation", string(operation)))
+	logMsg(fmt.Sprintf("Received expected response from '%s' operation", string(operation)))
 	fields[string(operation)+"_code"] = expectedCode
 }
 

--- a/plugins/inputs/smtp/smtp.go
+++ b/plugins/inputs/smtp/smtp.go
@@ -26,7 +26,6 @@ const (
 	ReadFailed
 	StringMismatch
 	TlsConfigError
-	CommandFailed
 )
 
 const (
@@ -263,8 +262,6 @@ func setResult(result ResultType, fields map[string]interface{}, tags map[string
 		tag = "string_mismatch"
 	case TlsConfigError:
 		tag = "tls_config_error"
-	case CommandFailed:
-		tag = "command_failed"
 	}
 
 	fields["result_code"] = uint64(result)

--- a/plugins/inputs/smtp/smtp.go
+++ b/plugins/inputs/smtp/smtp.go
@@ -30,14 +30,14 @@ const (
 )
 
 const (
-	Connect Operation = "connect"
-	Ehlo = "ehlo"
-	StartTls = "starttls"
-	MailFrom = "from"
-	RcptTo = "to"
-	Data = "data"
-	Body = "body"
-	Quit = "quit"
+	Connect  Operation = "connect"
+	Ehlo               = "ehlo"
+	StartTls           = "starttls"
+	MailFrom           = "from"
+	RcptTo             = "to"
+	Data               = "data"
+	Body               = "body"
+	Quit               = "quit"
 )
 
 // Smtp struct
@@ -49,7 +49,7 @@ type Smtp struct {
 	From        string
 	To          string
 	Body        string
-	StartTls         bool
+	StartTls    bool
 
 	internaltls.ClientConfig
 }
@@ -133,7 +133,6 @@ func (config *Smtp) SMTPGather() (tags map[string]string, fields map[string]inte
 		return tags, fields
 	}
 
-
 	// Perform required commands
 	// Commands are only executed if the previous one was successful
 	if success && config.Ehlo != "" {
@@ -142,7 +141,7 @@ func (config *Smtp) SMTPGather() (tags map[string]string, fields map[string]inte
 	if success && config.StartTls {
 		// read tls config
 		tlsConfig, err := config.ClientConfig.TLSConfig()
-		if err != nil || tlsConfig == nil{
+		if err != nil || tlsConfig == nil {
 			// cleanly close the connection
 			text.Cmd("QUIT")
 			// update failure status

--- a/plugins/inputs/smtp/smtp.go
+++ b/plugins/inputs/smtp/smtp.go
@@ -270,7 +270,7 @@ func setResult(result ResultType, fields map[string]interface{}, tags map[string
 
 func logMsg(msg string) {
 	if wlog.LogLevel() == wlog.DEBUG {
-		log.Println("smtp: "+msg)
+		log.Println("smtp: " + msg)
 	}
 }
 

--- a/plugins/inputs/smtp/smtp.go
+++ b/plugins/inputs/smtp/smtp.go
@@ -1,0 +1,233 @@
+package smtp
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"net/textproto"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+type ResultType uint64
+
+const (
+	Success ResultType = iota
+	Timeout
+	ConnectionFailed
+	ReadFailed
+	StringMismatch
+)
+
+// Smtp struct
+type Smtp struct {
+	Address     string
+	Timeout     internal.Duration
+	ReadTimeout internal.Duration
+	Ehlo        string
+	From        string
+	To          string
+	Body        string
+	Tls         bool
+}
+
+var description = "Automates an entire SMTP session and reports metrics"
+
+// Description will return a short string to explain what the plugin does.
+func (*Smtp) Description() string {
+	return description
+}
+
+var sampleConfig = `
+  ## Server address (default localhost)
+  address = "localhost:25"
+
+  ## Set initial connection timeout
+  # timeout = "10s"
+
+  ## Set read timeout
+  # read_timeout = "10s"
+
+  ## Optional value to provide to ehlo command 
+  # ehlo = "example.com"
+
+  ## Optional value to provide to mailfrom command 
+  # from = "me@example.com"
+
+  ## Optional value to provide to rcptto command
+  # to = "you@example.com"
+
+  ## Optional value to provide to data command
+  # body = "this is a test payload"
+
+  ## Optional tls config
+  # tls = false
+`
+
+// SampleConfig will return a complete configuration example with details about each field.
+func (*Smtp) SampleConfig() string {
+	return sampleConfig
+}
+
+func CheckResponse(r *textproto.Reader, operation string, expectedCode int, fields map[string]interface{}, tags map[string]string) (success bool) {
+	var err error
+	code, _, err := r.ReadResponse(expectedCode)
+	if err != nil {
+		if e, ok := err.(net.Error); ok && e.Timeout() {
+			setProtocolMetrics(Timeout, operation, code, fields, tags)
+		} else if e, ok := err.(*textproto.Error); ok && e.Code != 0 {
+			setProtocolMetrics(StringMismatch, operation, code, fields, tags)
+		} else {
+			setProtocolMetrics(ReadFailed, operation, code, fields, tags)
+		}
+		return false
+	}
+	setProtocolMetrics(Success, operation, code, fields, tags)
+	return true
+}
+
+// sends the smtp commands to the server
+// the data command expects an additional input to signal its end
+func WriteCmd(c net.Conn, m string) {
+	c.Write([]byte(m + "\r\n"))
+	if m == "DATA" {
+		c.Write([]byte(".\r\n"))
+	}
+}
+
+// SMTPGather will execute the full smtp session.
+// It will return a map[string]interface{} for fields and a map[string]string for tags
+func (config *Smtp) SMTPGather() (tags map[string]string, fields map[string]interface{}) {
+	// Prepare returns
+	tags = make(map[string]string)
+	fields = make(map[string]interface{})
+	// Start Timer
+	start := time.Now()
+	// Connecting
+	conn, err := net.DialTimeout("tcp", config.Address, config.Timeout.Duration)
+	// Prepare reader
+	reader := bufio.NewReader(conn)
+	tp := textproto.NewReader(reader)
+	// Stop timer
+	responseTime := time.Since(start).Seconds()
+	fields["connect_time"] = responseTime
+	// Handle error
+	if err != nil {
+		if e, ok := err.(net.Error); ok && e.Timeout() {
+			setResult(Timeout, fields, tags)
+		} else {
+			setResult(ConnectionFailed, fields, tags)
+		}
+		return tags, fields
+	}
+	defer conn.Close()
+
+	// Set the overall read timeout
+	conn.SetDeadline(time.Now().Add(config.ReadTimeout.Duration))
+
+	// Commands are only executed if the previous one was successful
+	success := CheckResponse(tp, "connect", 220, fields, tags)
+	if success && config.Ehlo != "" {
+		WriteCmd(conn, "EHLO "+config.Ehlo)
+		success = CheckResponse(tp, "ehlo", 250, fields, tags)
+	}
+	if success && config.From != "" {
+		WriteCmd(conn, "MAIL FROM:"+config.From)
+		success = CheckResponse(tp, "from", 250, fields, tags)
+	}
+	if success && config.To != "" {
+		WriteCmd(conn, "RCPT TO:"+config.To)
+		success = CheckResponse(tp, "to", 250, fields, tags)
+	}
+	if success && config.Body != "" {
+		WriteCmd(conn, "DATA\r\n"+config.Body)
+		// First check the response from "DATA"
+		success = CheckResponse(tp, "data", 354, fields, tags)
+		if success {
+			// then the response from the body
+			success = CheckResponse(tp, "body", 250, fields, tags)
+		}
+	}
+
+	// Send a quit whether the previous commands succeeded or not
+	WriteCmd(conn, "QUIT")
+	success = CheckResponse(tp, "quit", 221, fields, tags)
+
+	responseTime = time.Since(start).Seconds()
+
+	fields["total_time"] = responseTime
+	return tags, fields
+}
+
+// Gather is called by telegraf when the plugin is executed on its interval.
+// It will call SMTPGather to generate metrics and also fill an Accumulator that is supplied.
+func (smtp *Smtp) Gather(acc telegraf.Accumulator) error {
+	// Set default values
+	if smtp.Timeout.Duration == 0 {
+		smtp.Timeout.Duration = time.Second
+	}
+	if smtp.ReadTimeout.Duration == 0 {
+		smtp.ReadTimeout.Duration = time.Second * 10
+	}
+	// Prepare host and port
+	host, port, err := net.SplitHostPort(smtp.Address)
+	if err != nil {
+		return err
+	}
+	if host == "" {
+		smtp.Address = "localhost:" + port
+	}
+	if port == "" {
+		return errors.New("Bad port")
+	}
+	// Prepare data
+	tags := map[string]string{"server": host, "port": port}
+	var fields map[string]interface{}
+	var returnTags map[string]string
+	// Gather data
+	returnTags, fields = smtp.SMTPGather()
+
+	for key, value := range returnTags {
+		tags[key] = value
+	}
+	// Merge the tags
+	for k, v := range returnTags {
+		tags[k] = v
+	}
+	// Add metrics
+	acc.AddFields("smtp", fields, tags)
+	return nil
+}
+
+func setProtocolMetrics(result ResultType, operation string, foundCode int, fields map[string]interface{}, tags map[string]string) {
+	setResult(result, fields, tags)
+	fields[operation+"_code"] = foundCode
+}
+
+func setResult(result ResultType, fields map[string]interface{}, tags map[string]string) {
+	var tag string
+	switch result {
+	case Success:
+		tag = "success"
+	case Timeout:
+		tag = "timeout"
+	case ConnectionFailed:
+		tag = "connection_failed"
+	case ReadFailed:
+		tag = "read_failed"
+	case StringMismatch:
+		tag = "string_mismatch"
+	}
+
+	tags["result"] = tag
+	fields["result_code"] = uint64(result)
+}
+
+func init() {
+	inputs.Add("smtp", func() telegraf.Input {
+		return &Smtp{}
+	})
+}

--- a/plugins/inputs/smtp/smtp.go
+++ b/plugins/inputs/smtp/smtp.go
@@ -189,10 +189,6 @@ func (smtp *Smtp) Gather(acc telegraf.Accumulator) error {
 	var returnTags map[string]string
 	// Gather data
 	returnTags, fields = smtp.SMTPGather()
-
-	for key, value := range returnTags {
-		tags[key] = value
-	}
 	// Merge the tags
 	for k, v := range returnTags {
 		tags[k] = v

--- a/plugins/inputs/smtp/smtp_test.go
+++ b/plugins/inputs/smtp/smtp_test.go
@@ -147,8 +147,8 @@ func TestSmtpTlsSession_Success(t *testing.T) {
 	testSmtpHelper(t, testConfig, fields, tags)
 }
 
-func TestSmtpSecureTlsSession_Success(t *testing.T) {
-	fields, tags := getFieldsAndTags("success", 0, true, 220, 250, 220, 250, 250, 354, 250, 221)
+func TestSmtpSecureTlsSession_Fail(t *testing.T) {
+	fields, tags := getFieldsAndTags("tls_config_error", 5, true, 220, 250)
 	testConfig := testConfig{
 		connectionEndPhase: 0,
 		tls:                true,
@@ -318,7 +318,7 @@ func SmtpServer(t *testing.T, wg *sync.WaitGroup, config testConfig) {
 		} else if strings.HasPrefix(data, "RCPT TO:") {
 			conn.Write([]byte("250 2.1.5 Ok\r\n"))
 		} else if config.connectionEndPhase == LateTimeout {
-			time.Sleep(getDefaultSmtpConfig().ReadTimeout.Duration + 1*time.Second)
+			time.Sleep(getDefaultSmtpConfig().ReadTimeout.Duration + time.Second)
 			wg.Done()
 			return
 		} else if config.connectionEndPhase == FailData {

--- a/plugins/inputs/smtp/smtp_test.go
+++ b/plugins/inputs/smtp/smtp_test.go
@@ -126,6 +126,11 @@ func TestSmtpFullSession_Success(t *testing.T) {
 	testSmtpHelper(t, 0, fields, tags)
 }
 
+func TestSmtp_FailTimeout(t *testing.T) {
+	fields, tags := getFieldsAndTags("timeout", 1, 0, 0)
+	testSmtpHelper(t, ConnectionTimeout, fields, tags)
+}
+
 func TestSmtp_FailEhlo(t *testing.T) {
 	fields, tags := getFieldsAndTags("read_failed", 3, 220, 0, 0)
 	testSmtpHelper(t, Ehlo, fields, tags)
@@ -155,11 +160,6 @@ func TestSmtp_FailPayload(t *testing.T) {
 func TestSmtp_FailQuit(t *testing.T) {
 	fields, tags := getFieldsAndTags("string_mismatch", 4, 220, 250, 250, 250, 354, 250, 999)
 	testSmtpHelper(t, Quit, fields, tags)
-}
-
-func TestSmtp_FailTimeout(t *testing.T) {
-	fields, tags := getFieldsAndTags("timeout", 1, 0, 0)
-	testSmtpHelper(t, ConnectionTimeout, fields, tags)
 }
 
 // codes must be provided in the same order as the codeTypes array
@@ -209,10 +209,10 @@ func SmtpServer(t *testing.T, wg *sync.WaitGroup, resp serverConfig) {
 	tp := textproto.NewReader(reader)
 
 	if resp.connectionEndPhase == ConnectionTimeout {
-		wg.Done()
 		time.Sleep(getDefaultSmtpConfig().ReadTimeout.Duration + 1*time.Second)
 		conn.Close()
 		tcpServer.Close()
+		wg.Done()
 		return
 	}
 

--- a/plugins/inputs/smtp/smtp_test.go
+++ b/plugins/inputs/smtp/smtp_test.go
@@ -27,8 +27,8 @@ type testConfig struct {
 	// defines the step at which the connection should close
 	// the connection will close directly before the given step is executed
 	connectionEndPhase ConnectionEndPhase
-	tls bool
-	tlsInsecure bool
+	tls                bool
+	tlsInsecure        bool
 }
 
 type ConnectionEndPhase int
@@ -96,7 +96,7 @@ func TestConnectionError(t *testing.T) {
 		map[string]interface{}{
 			"result_code":  uint64(2),
 			"connect_time": 1.0,
-			"total_time": 2.0,
+			"total_time":   2.0,
 		},
 		map[string]string{
 			"result": "connection_failed",
@@ -349,12 +349,12 @@ func getDefaultSmtpConfig() Smtp {
 	return Smtp{
 		Address:     "127.0.0.1:2004",
 		Timeout:     internal.Duration{Duration: time.Second},
-		ReadTimeout:     internal.Duration{Duration: time.Second * 2},
+		ReadTimeout: internal.Duration{Duration: time.Second * 2},
 		Ehlo:        "me@test.com",
 		From:        "me2@test.com",
 		To:          "me3@test.com",
 		Body:        "testdata 12345",
-		StartTls:	false,
+		StartTls:    false,
 	}
 }
 

--- a/plugins/inputs/smtp/smtp_test.go
+++ b/plugins/inputs/smtp/smtp_test.go
@@ -1,0 +1,284 @@
+package smtp
+
+import (
+	"bufio"
+	"net"
+	"net/textproto"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type serverConfig struct {
+	// defines the step at which the connection should close
+	// the connection will close directly before the given step is executed
+	connectionEndPhase ConnectionEndPhase
+}
+
+type ConnectionEndPhase int
+
+const (
+	ConnectionTimeout ConnectionEndPhase = iota + 1
+	Ehlo
+	From
+	To
+	Data
+	Payload
+	Quit
+)
+
+func TestSample(t *testing.T) {
+	c := &Smtp{}
+	output := c.SampleConfig()
+	if output != sampleConfig {
+		t.Error("Sample config doesn't match")
+	}
+}
+
+func TestDescription(t *testing.T) {
+	c := &Smtp{}
+	output := c.Description()
+	if output != description {
+		t.Error("Description output is not correct")
+	}
+}
+
+func TestNoPort(t *testing.T) {
+	var acc testutil.Accumulator
+	c := Smtp{
+		Address: ":",
+	}
+	err1 := c.Gather(&acc)
+	require.Error(t, err1)
+	assert.Equal(t, "Bad port", err1.Error())
+}
+
+func TestAddressOnly(t *testing.T) {
+	var acc testutil.Accumulator
+	c := Smtp{
+		Address: "127.0.0.1",
+	}
+	err1 := c.Gather(&acc)
+	require.Error(t, err1)
+	assert.Equal(t, "address 127.0.0.1: missing port in address", err1.Error())
+}
+
+func TestConnectionError(t *testing.T) {
+	var acc testutil.Accumulator
+	// Init plugin
+	c := getDefaultSmtpConfig()
+	// Error
+	err1 := c.Gather(&acc)
+	for _, p := range acc.Metrics {
+		p.Fields["connect_time"] = 1.0
+	}
+	require.NoError(t, err1)
+	acc.AssertContainsTaggedFields(t,
+		"smtp",
+		map[string]interface{}{
+			"result_code":  uint64(2),
+			"connect_time": 1.0,
+		},
+		map[string]string{
+			"result": "connection_failed",
+			"server": "127.0.0.1",
+			"port":   "2004",
+		},
+	)
+}
+
+func testSmtpHelper(t *testing.T, phase ConnectionEndPhase, fields map[string]interface{}, tags map[string]string) {
+	var wg sync.WaitGroup
+	var acc testutil.Accumulator
+	// Init plugin
+	c := getDefaultSmtpConfig()
+
+	// Start TCP server
+	wg.Add(1)
+	go SmtpServer(t, &wg, serverConfig{
+		connectionEndPhase: phase,
+	})
+	wg.Wait()
+	// Connect
+	wg.Add(1)
+	err1 := c.Gather(&acc)
+	wg.Wait()
+	// Override response time
+	for _, p := range acc.Metrics {
+		p.Fields["connect_time"] = 1.0
+		p.Fields["total_time"] = 2.0
+	}
+	require.NoError(t, err1)
+	acc.AssertContainsTaggedFields(t, "smtp", fields, tags)
+	// Waiting TCPserver
+	wg.Wait()
+}
+
+func TestSmtpFullSession_Success(t *testing.T) {
+	fields, tags := getFieldsAndTags("success", 0, 220, 250, 250, 250, 354, 250, 221)
+	testSmtpHelper(t, 0, fields, tags)
+}
+
+func TestSmtp_FailEhlo(t *testing.T) {
+	fields, tags := getFieldsAndTags("read_failed", 3, 220, 0, 0)
+	testSmtpHelper(t, Ehlo, fields, tags)
+}
+
+func TestSmtp_FailFrom(t *testing.T) {
+	fields, tags := getFieldsAndTags("read_failed", 3, 220, 250, 0, 0)
+	testSmtpHelper(t, From, fields, tags)
+}
+
+func TestSmtp_FailTo(t *testing.T) {
+	fields, tags := getFieldsAndTags("read_failed", 3, 220, 250, 250, 0, 0)
+	testSmtpHelper(t, To, fields, tags)
+}
+
+func TestSmtp_FailData(t *testing.T) {
+	fields, tags := getFieldsAndTags("read_failed", 3, 220, 250, 250, 250, 0, 0)
+	testSmtpHelper(t, Data, fields, tags)
+}
+
+func TestSmtp_FailPayload(t *testing.T) {
+	fields, tags := getFieldsAndTags("read_failed", 3, 220, 250, 250, 250, 354, 0, 0)
+	testSmtpHelper(t, Payload, fields, tags)
+}
+
+// Rather than closing the connection when failing here, we instead get an unexpected response code
+func TestSmtp_FailQuit(t *testing.T) {
+	fields, tags := getFieldsAndTags("string_mismatch", 4, 220, 250, 250, 250, 354, 250, 999)
+	testSmtpHelper(t, Quit, fields, tags)
+}
+
+func TestSmtp_FailTimeout(t *testing.T) {
+	fields, tags := getFieldsAndTags("timeout", 1, 0, 0)
+	testSmtpHelper(t, ConnectionTimeout, fields, tags)
+}
+
+// codes must be provided in the same order as the codeTypes array
+func getFieldsAndTags(status string, result int, codes ...int) (fields map[string]interface{}, tags map[string]string) {
+	codeTypes := []string{
+		"connect_code",
+		"ehlo_code",
+		"from_code",
+		"to_code",
+		"data_code",
+		"body_code",
+	}
+
+	fields = map[string]interface{}{
+		"result_code":  uint64(result),
+		"connect_time": 1.0,
+		"total_time":   2.0,
+	}
+	tags = map[string]string{
+		"result": status,
+		"server": "127.0.0.1",
+		"port":   "2004",
+	}
+
+	// populate the codes provided into the corresponding metric name
+	// codes are only provided if that step is executed
+	// the last code is always for "quit"
+	for i, code := range codes {
+		if i == len(codes)-1 {
+			fields["quit_code"] = code
+		} else {
+			fields[codeTypes[i]] = code
+		}
+
+	}
+
+	return fields, tags
+}
+
+//noinspection GoUnhandledErrorResult
+func SmtpServer(t *testing.T, wg *sync.WaitGroup, resp serverConfig) {
+	tcpAddr, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:2004")
+	tcpServer, _ := net.ListenTCP("tcp", tcpAddr)
+	wg.Done()
+	conn, _ := tcpServer.AcceptTCP()
+	reader := bufio.NewReader(conn)
+	tp := textproto.NewReader(reader)
+
+	if resp.connectionEndPhase == ConnectionTimeout {
+		wg.Done()
+		time.Sleep(getDefaultSmtpConfig().ReadTimeout.Duration + 1*time.Second)
+		conn.Close()
+		tcpServer.Close()
+		return
+	}
+
+	conn.Write([]byte("220 myhostname ESMTP Postfix (Ubuntu)\n"))
+
+	for {
+		data, err := tp.ReadLine()
+		if err != nil {
+			t.Error(err)
+			break
+		}
+		if resp.connectionEndPhase == Ehlo {
+			conn.Close()
+			break
+		} else if strings.HasPrefix(data, "EHLO") {
+			conn.Write([]byte("250-myhostname\n"))
+			conn.Write([]byte("250-PIPELINING\n"))
+			conn.Write([]byte("250-SIZE 10240000\n"))
+			conn.Write([]byte("250-VRFY\n"))
+			conn.Write([]byte("250-ETRN\n"))
+			conn.Write([]byte("250-STARTTLS\n"))
+			conn.Write([]byte("250-ENHANCEDSTATUSCODES\n"))
+			conn.Write([]byte("250-8BITMIME\n"))
+			conn.Write([]byte("250-DSN\n"))
+			conn.Write([]byte("250 SMTPUTF8\n"))
+		} else if resp.connectionEndPhase == From {
+			conn.Close()
+			break
+		} else if strings.HasPrefix(data, "MAIL FROM:") {
+			conn.Write([]byte("250 2.1.0 Ok\n"))
+		} else if resp.connectionEndPhase == To {
+			conn.Close()
+			break
+		} else if strings.HasPrefix(data, "RCPT TO:") {
+			conn.Write([]byte("250 2.1.5 Ok\n"))
+		} else if resp.connectionEndPhase == Data {
+			conn.Close()
+			break
+		} else if strings.HasPrefix(data, "DATA") {
+			conn.Write([]byte("354 End data with <CR><LF>.<CR><LF>\n"))
+		} else if resp.connectionEndPhase == Payload {
+			conn.Close()
+			break
+		} else if strings.HasPrefix(data, "testdata") {
+			conn.Write([]byte("250 2.0.0 Ok: queued as C7CAA3F279\n"))
+		} else if resp.connectionEndPhase == Quit {
+			conn.Write([]byte("999 This is a fake error\n"))
+			break
+		} else if strings.HasPrefix(data, "QUIT") {
+			conn.Write([]byte("221 2.0.0 Bye\n"))
+			break
+		}
+	}
+	tcpServer.Close()
+	wg.Done()
+}
+
+func getDefaultSmtpConfig() Smtp {
+	return Smtp{
+		Address:     "127.0.0.1:2004",
+		Timeout:     internal.Duration{Duration: time.Second},
+		ReadTimeout: internal.Duration{Duration: time.Second * 3},
+		Ehlo:        "me@test.com",
+		From:        "me2@test.com",
+		To:          "me3@test.com",
+		Body:        "testdata 12345",
+		Tls:         false,
+	}
+}

--- a/plugins/inputs/smtp/smtp_test.go
+++ b/plugins/inputs/smtp/smtp_test.go
@@ -216,7 +216,7 @@ func SmtpServer(t *testing.T, wg *sync.WaitGroup, resp serverConfig) {
 		return
 	}
 
-	conn.Write([]byte("220 myhostname ESMTP Postfix (Ubuntu)\n"))
+	conn.Write([]byte("220 myhostname ESMTP Postfix (Ubuntu)\r\n"))
 
 	for {
 		data, err := tp.ReadLine()
@@ -228,41 +228,41 @@ func SmtpServer(t *testing.T, wg *sync.WaitGroup, resp serverConfig) {
 			conn.Close()
 			break
 		} else if strings.HasPrefix(data, "EHLO") {
-			conn.Write([]byte("250-myhostname\n"))
-			conn.Write([]byte("250-PIPELINING\n"))
-			conn.Write([]byte("250-SIZE 10240000\n"))
-			conn.Write([]byte("250-VRFY\n"))
-			conn.Write([]byte("250-ETRN\n"))
-			conn.Write([]byte("250-STARTTLS\n"))
-			conn.Write([]byte("250-ENHANCEDSTATUSCODES\n"))
-			conn.Write([]byte("250-8BITMIME\n"))
-			conn.Write([]byte("250-DSN\n"))
-			conn.Write([]byte("250 SMTPUTF8\n"))
+			conn.Write([]byte("250-myhostname\r\n"))
+			conn.Write([]byte("250-PIPELINING\r\n"))
+			conn.Write([]byte("250-SIZE 10240000\r\n"))
+			conn.Write([]byte("250-VRFY\r\n"))
+			conn.Write([]byte("250-ETRN\r\n"))
+			conn.Write([]byte("250-STARTTLS\r\n"))
+			conn.Write([]byte("250-ENHANCEDSTATUSCODES\r\n"))
+			conn.Write([]byte("250-8BITMIME\r\n"))
+			conn.Write([]byte("250-DSN\r\n"))
+			conn.Write([]byte("250 SMTPUTF8\r\n"))
 		} else if resp.connectionEndPhase == From {
 			conn.Close()
 			break
 		} else if strings.HasPrefix(data, "MAIL FROM:") {
-			conn.Write([]byte("250 2.1.0 Ok\n"))
+			conn.Write([]byte("250 2.1.0 Ok\r\n"))
 		} else if resp.connectionEndPhase == To {
 			conn.Close()
 			break
 		} else if strings.HasPrefix(data, "RCPT TO:") {
-			conn.Write([]byte("250 2.1.5 Ok\n"))
+			conn.Write([]byte("250 2.1.5 Ok\r\n"))
 		} else if resp.connectionEndPhase == Data {
 			conn.Close()
 			break
 		} else if strings.HasPrefix(data, "DATA") {
-			conn.Write([]byte("354 End data with <CR><LF>.<CR><LF>\n"))
+			conn.Write([]byte("354 End data with <CR><LF>.<CR><LF>\r\n"))
 		} else if resp.connectionEndPhase == Payload {
 			conn.Close()
 			break
 		} else if strings.HasPrefix(data, "testdata") {
-			conn.Write([]byte("250 2.0.0 Ok: queued as C7CAA3F279\n"))
+			conn.Write([]byte("250 2.0.0 Ok: queued as C7CAA3F279\r\n"))
 		} else if resp.connectionEndPhase == Quit {
-			conn.Write([]byte("999 This is a fake error\n"))
+			conn.Write([]byte("999 This is a fake error\r\n"))
 			break
 		} else if strings.HasPrefix(data, "QUIT") {
-			conn.Write([]byte("221 2.0.0 Bye\n"))
+			conn.Write([]byte("221 2.0.0 Bye\r\n"))
 			break
 		}
 	}

--- a/plugins/inputs/smtp/smtp_test.go
+++ b/plugins/inputs/smtp/smtp_test.go
@@ -349,7 +349,7 @@ func getDefaultSmtpConfig() Smtp {
 	return Smtp{
 		Address:     "127.0.0.1:2004",
 		Timeout:     internal.Duration{Duration: time.Second},
-		ReadTimeout:     internal.Duration{Duration: time.Second * 3},
+		ReadTimeout:     internal.Duration{Duration: time.Second * 2},
 		Ehlo:        "me@test.com",
 		From:        "me2@test.com",
 		To:          "me3@test.com",

--- a/plugins/inputs/smtp/smtp_test.go
+++ b/plugins/inputs/smtp/smtp_test.go
@@ -34,16 +34,16 @@ type ConnectionEndPhase int
 const (
 	ConnectionTimeout ConnectionEndPhase = iota + 1
 	LateTimeout
-	Ehlo
-	From
-	To
-	Data
-	Payload
-	Quit
+	FailEhlo
+	FailFrom
+	FailTo
+	FailData
+	FailPayload
+	FailQuit
 )
 
 func TestSample(t *testing.T) {
-	c := &SmtpConfig{}
+	c := &Smtp{}
 	output := c.SampleConfig()
 	if output != sampleConfig {
 		t.Error("Sample config doesn't match")
@@ -51,7 +51,7 @@ func TestSample(t *testing.T) {
 }
 
 func TestDescription(t *testing.T) {
-	c := &SmtpConfig{}
+	c := &Smtp{}
 	output := c.Description()
 	if output != description {
 		t.Error("Description output is not correct")
@@ -60,7 +60,7 @@ func TestDescription(t *testing.T) {
 
 func TestNoPort(t *testing.T) {
 	var acc testutil.Accumulator
-	c := SmtpConfig{
+	c := Smtp{
 		Address: ":",
 	}
 	err1 := c.Gather(&acc)
@@ -70,7 +70,7 @@ func TestNoPort(t *testing.T) {
 
 func TestAddressOnly(t *testing.T) {
 	var acc testutil.Accumulator
-	c := SmtpConfig{
+	c := Smtp{
 		Address: "127.0.0.1",
 	}
 	err1 := c.Gather(&acc)
@@ -110,7 +110,7 @@ func testSmtpHelper(t *testing.T, testConfig testConfig, fields map[string]inter
 	// Init plugin
 	c := getDefaultSmtpConfig()
 	if testConfig.tls {
-		c = getTlsSmtpConfig(testConfig.tlsInsecure)
+		c = getTlsSmtp(testConfig.tlsInsecure)
 	}
 
 	// Start TCP server
@@ -133,12 +133,12 @@ func testSmtpHelper(t *testing.T, testConfig testConfig, fields map[string]inter
 }
 
 func TestSmtpFullSession_Success(t *testing.T) {
-	fields, tags := getFieldsAndTags("success", 0, false, 220, 250, 250, 250, 250, 221)
+	fields, tags := getFieldsAndTags("success", 0, false, 220, 250, 250, 250, 354, 250, 221)
 	testSmtpHelper(t, testConfig{}, fields, tags)
 }
 
 func TestSmtpTlsSession_Success(t *testing.T) {
-	fields, tags := getFieldsAndTags("success", 0, true, 220, 250, 220, 250, 250, 250, 221)
+	fields, tags := getFieldsAndTags("success", 0, true, 220, 250, 220, 250, 250, 354, 250, 221)
 	testConfig := testConfig{
 		connectionEndPhase: 0,
 		tls:                true,
@@ -160,39 +160,39 @@ func TestSmtp_FailTimeoutAfterRcptTo(t *testing.T) {
 }
 
 func TestSmtp_FailEhlo(t *testing.T) {
-	fields, tags := getFieldsAndTags("ehlo_failed", 4, false, 220, 421)
-	testConfig := testConfig{connectionEndPhase: Ehlo}
+	fields, tags := getFieldsAndTags("string_mismatch", 4, false, 220, 421)
+	testConfig := testConfig{connectionEndPhase: FailEhlo}
 	testSmtpHelper(t, testConfig, fields, tags)
 }
 
 func TestSmtp_FailFrom(t *testing.T) {
-	fields, tags := getFieldsAndTags("from_failed", 6, false, 220, 250, 423)
-	testConfig := testConfig{connectionEndPhase: From}
+	fields, tags := getFieldsAndTags("string_mismatch", 4, false, 220, 250, 423)
+	testConfig := testConfig{connectionEndPhase: FailFrom}
 	testSmtpHelper(t, testConfig, fields, tags)
 }
 
 func TestSmtp_FailTo(t *testing.T) {
-	fields, tags := getFieldsAndTags("to_failed", 7, false, 220, 250, 250, 424)
-	testConfig := testConfig{connectionEndPhase: To}
+	fields, tags := getFieldsAndTags("string_mismatch", 4, false, 220, 250, 250, 424)
+	testConfig := testConfig{connectionEndPhase: FailTo}
 	testSmtpHelper(t, testConfig, fields, tags)
 }
 
 func TestSmtp_FailData(t *testing.T) {
-	fields, tags := getFieldsAndTags("data_failed", 8, false, 220, 250, 250, 250, 425)
-	testConfig := testConfig{connectionEndPhase: Data}
+	fields, tags := getFieldsAndTags("string_mismatch", 4, false, 220, 250, 250, 250, 425)
+	testConfig := testConfig{connectionEndPhase: FailData}
 	testSmtpHelper(t, testConfig, fields, tags)
 }
 
 func TestSmtp_FailPayload(t *testing.T) {
-	fields, tags := getFieldsAndTags("data_failed", 8, false, 220, 250, 250, 250, 425)
-	testConfig := testConfig{connectionEndPhase: Payload}
+	fields, tags := getFieldsAndTags("string_mismatch", 4, false, 220, 250, 250, 250, 354, 425)
+	testConfig := testConfig{connectionEndPhase: FailPayload}
 	testSmtpHelper(t, testConfig, fields, tags)
 }
 
 // Rather than closing the connection when failing here, we instead get an unexpected response code
 func TestSmtp_FailQuit(t *testing.T) {
-	fields, tags := getFieldsAndTags("quit_failed", 9, false, 220, 250, 250, 250, 250, 426)
-	testConfig := testConfig{connectionEndPhase: Quit}
+	fields, tags := getFieldsAndTags("string_mismatch", 4, false, 220, 250, 250, 250, 354, 250, 426)
+	testConfig := testConfig{connectionEndPhase: FailQuit}
 	testSmtpHelper(t, testConfig, fields, tags)
 }
 
@@ -205,6 +205,7 @@ func getFieldsAndTags(status string, result int, tls bool, codes ...int) (fields
 		"from_code",
 		"to_code",
 		"data_code",
+		"body_code",
 		"quit_code",
 	}
 
@@ -249,7 +250,7 @@ func SmtpServer(t *testing.T, wg *sync.WaitGroup, config testConfig) {
 	tp := textproto.NewReader(reader)
 
 	if config.connectionEndPhase == ConnectionTimeout {
-		time.Sleep(getDefaultSmtpConfig().Timeout.Duration + time.Second)
+		time.Sleep(getDefaultSmtpConfig().ReadTimeout.Duration + time.Second)
 		wg.Done()
 		return
 	}
@@ -265,7 +266,7 @@ func SmtpServer(t *testing.T, wg *sync.WaitGroup, config testConfig) {
 		}
 		require.NoError(t, err)
 
-		if config.connectionEndPhase == Ehlo {
+		if config.connectionEndPhase == FailEhlo {
 			conn.Write([]byte("421 This is a fake error\r\n"))
 		} else if strings.HasPrefix(data, "EHLO") {
 			conn.Write([]byte("250-myhostname\r\n"))
@@ -289,27 +290,27 @@ func SmtpServer(t *testing.T, wg *sync.WaitGroup, config testConfig) {
 				reader := bufio.NewReader(conn)
 				tp = textproto.NewReader(reader)
 			}
-		} else if config.connectionEndPhase == From {
+		} else if config.connectionEndPhase == FailFrom {
 			conn.Write([]byte("423 This is a fake error\r\n"))
 		} else if strings.HasPrefix(data, "MAIL FROM:") {
 			conn.Write([]byte("250 2.1.0 Ok\r\n"))
-		} else if config.connectionEndPhase == To {
+		} else if config.connectionEndPhase == FailTo {
 			conn.Write([]byte("424 This is a fake error\r\n"))
 		} else if strings.HasPrefix(data, "RCPT TO:") {
 			conn.Write([]byte("250 2.1.5 Ok\r\n"))
 		} else if config.connectionEndPhase == LateTimeout {
-			time.Sleep(getDefaultSmtpConfig().Timeout.Duration + 1*time.Second)
+			time.Sleep(getDefaultSmtpConfig().ReadTimeout.Duration + 1*time.Second)
 			wg.Done()
 			return
-		} else if config.connectionEndPhase == Data {
+		} else if config.connectionEndPhase == FailData {
 			conn.Write([]byte("425 This is a fake error\r\n"))
 		} else if strings.HasPrefix(data, "DATA") {
 			conn.Write([]byte("354 End data with <CR><LF>.<CR><LF>\r\n"))
-		} else if config.connectionEndPhase == Payload {
+		} else if config.connectionEndPhase == FailPayload {
 			conn.Write([]byte("425 This is a fake error\r\n"))
 		} else if strings.HasPrefix(data, "testdata") {
 			conn.Write([]byte("250 2.0.0 Ok: queued as C7CAA3F279\r\n"))
-		} else if config.connectionEndPhase == Quit {
+		} else if config.connectionEndPhase == FailQuit {
 			conn.Write([]byte("426 This is a fake error\r\n"))
 		} else if strings.HasPrefix(data, "QUIT") {
 			conn.Write([]byte("221 2.0.0 Bye\r\n"))
@@ -318,10 +319,11 @@ func SmtpServer(t *testing.T, wg *sync.WaitGroup, config testConfig) {
 	wg.Done()
 }
 
-func getDefaultSmtpConfig() SmtpConfig {
-	return SmtpConfig{
+func getDefaultSmtpConfig() Smtp {
+	return Smtp{
 		Address:     "127.0.0.1:2004",
 		Timeout:     internal.Duration{Duration: time.Second},
+		ReadTimeout:     internal.Duration{Duration: time.Second * 3},
 		Ehlo:        "me@test.com",
 		From:        "me2@test.com",
 		To:          "me3@test.com",
@@ -330,7 +332,7 @@ func getDefaultSmtpConfig() SmtpConfig {
 	}
 }
 
-func getTlsSmtpConfig(insecure bool) SmtpConfig {
+func getTlsSmtp(insecure bool) Smtp {
 	conf := getDefaultSmtpConfig()
 	conf.StartTls = true
 	conf.ClientConfig = *getTlsClientConfig(insecure)

--- a/plugins/inputs/smtp/smtp_test.go
+++ b/plugins/inputs/smtp/smtp_test.go
@@ -147,6 +147,16 @@ func TestSmtpTlsSession_Success(t *testing.T) {
 	testSmtpHelper(t, testConfig, fields, tags)
 }
 
+func TestSmtpSecureTlsSession_Success(t *testing.T) {
+	fields, tags := getFieldsAndTags("success", 0, true, 220, 250, 220, 250, 250, 354, 250, 221)
+	testConfig := testConfig{
+		connectionEndPhase: 0,
+		tls:                true,
+		tlsInsecure:        false,
+	}
+	testSmtpHelper(t, testConfig, fields, tags)
+}
+
 func TestSmtp_FailTimeoutConnection(t *testing.T) {
 	fields, tags := getFieldsAndTags("timeout", 1, false)
 	testConfig := testConfig{connectionEndPhase: ConnectionTimeout}

--- a/plugins/inputs/smtp/smtp_test.go
+++ b/plugins/inputs/smtp/smtp_test.go
@@ -130,8 +130,6 @@ func testSmtpHelper(t *testing.T, testConfig testConfig, fields map[string]inter
 	}
 	require.NoError(t, err1)
 	acc.AssertContainsTaggedFields(t, "smtp", fields, tags)
-	// Waiting TCPserver
-	wg.Wait()
 }
 
 func TestSmtpFullSession_Success(t *testing.T) {


### PR DESCRIPTION
# Fixes

https://jira.rax.io/browse/SALUS-802

# What

Adds a new input plugin to execute a full smtp session

# How

Started with the `net_response` plugin and modified it to work for the smtp protocol.

Due to difficulties with `starttls` I attempted to reimplement this using the `net/smtp` client in https://github.com/racker/telegraf/pull/4.  For some reason I couldn't get timeouts to work there.  I initially tried utilizing `conn.SetReadDeadline` but it did not work.  I then went down the rabbit hole of channels and context which led to a bunch of learning but not much progress.

In the end I had to reverse engineer parts of that client to get `starttls` to work.  With that I am still not sure why that client did not work as I am effectively doing the same thing for timeouts.  I'll spend a little more time digging into that - my concern is that I'm doing something wrong here that will only become evident when we run it against real smtp servers.

**UPDATE:** I retried my previous attempts using the net/smtp client and things started working.  I've now added another commit that changes this once again to use that client.  All tests pass.

# Why

To replace ele's remote.smtp check.  We can monitor this entire flow:

```
root@jjb-smtp-02-2020:~# telnet localhost 25
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
220 jjb-smtp-02-2020 ESMTP Postfix (Ubuntu)
EHLO me.com
250-jjb-smtp-02-2020
250-PIPELINING
250-SIZE 10240000
250-VRFY
250-ETRN
250-STARTTLS
250-ENHANCEDSTATUSCODES
250-8BITMIME
250-DSN
250 SMTPUTF8
MAIL FROM:james@me.com
250 2.1.0 Ok
RCPT TO:me@me.com
250 2.1.5 Ok
DATA
354 End data with <CR><LF>.<CR><LF>
test
test
me
.
250 2.0.0 Ok: queued as 3B4763F279
QUIT
221 2.0.0 Bye
Connection closed by foreign host.
```

# TODO

- [x] Add Readme
- [ ] Add Changelog - will do that in a new PR to include the prior changes
- [ ] Add a test using a trusted cert  - I'm not too sure how to do this.

Tried using the following config but debuging the test shows this error `first record does not look like a TLS handshake`.

```
		return &internaltls.ClientConfig{
			TLSKey: pki.ClientKeyPath(),
			TLSCert: pki.ClientCertPath(),
			TLSCA: pki.CACertPath(),
			InsecureSkipVerify: insecure,
		}
```

I'm not sure if that's a problem with my test server, the server or client tls config, or something else.